### PR TITLE
Fixed project to use RSASSA-PSS on Android

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,8 +1,6 @@
 plugins {
     id 'com.android.application'
     id 'kotlin-android'
-
-
 }
 
 android {
@@ -35,12 +33,12 @@ android {
 
 dependencies {
 
-    implementation ("io.jsonwebtoken:jjwt-api:0.11.5")
-    implementation ("io.jsonwebtoken:jjwt-impl:0.11.5")
-    implementation ("io.jsonwebtoken:jjwt-orgjson:0.11.5")
-
-    // https://mvnrepository.com/artifact/org.bouncycastle/bcpkix-jdk15to18
-    implementation("org.bouncycastle:bcpkix-jdk15to18:1.71")
+    api("io.jsonwebtoken:jjwt-api:0.11.5")
+    runtimeOnly("io.jsonwebtoken:jjwt-impl:0.11.5")
+    runtimeOnly('io.jsonwebtoken:jjwt-orgjson:0.11.5') {
+        exclude(group: 'org.json', module: 'json') // provided by Android natively
+    }
+    implementation("org.bouncycastle:bcpkix-jdk18on:1.71")
 
     implementation 'androidx.core:core-ktx:1.7.0'
     implementation 'androidx.appcompat:appcompat:1.4.1'

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -19,3 +19,14 @@
 # If you keep the line number information, uncomment this to
 # hide the original source file name.
 #-renamesourcefileattribute SourceFile
+
+-keepattributes InnerClasses
+
+-keep class io.jsonwebtoken.** { *; }
+-keepnames class io.jsonwebtoken.* { *; }
+-keepnames interface io.jsonwebtoken.* { *; }
+
+-keep class org.bouncycastle.** { *; }
+-keepnames class org.bouncycastle.** { *; }
+-dontwarn org.bouncycastle.**
+

--- a/app/src/main/java/com/eyehail/smallproject/MainActivity.kt
+++ b/app/src/main/java/com/eyehail/smallproject/MainActivity.kt
@@ -6,17 +6,26 @@ import android.os.Bundle
 import android.util.Log
 import io.jsonwebtoken.Jwts
 import io.jsonwebtoken.SignatureAlgorithm
+import org.bouncycastle.jce.provider.BouncyCastleProvider
 import org.bouncycastle.util.io.pem.PemObject
 import org.bouncycastle.util.io.pem.PemReader
 import java.io.BufferedReader
-import java.io.File
 import java.io.InputStreamReader
 import java.security.KeyFactory
+import java.security.Security
 import java.security.spec.PKCS8EncodedKeySpec
 import java.time.Instant
 import java.util.*
 
 class MainActivity : AppCompatActivity() {
+
+    companion object {
+        init {
+            Security.removeProvider("BC")
+            Security.addProvider(BouncyCastleProvider())
+        }
+    }
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_main)


### PR DESCRIPTION
- Ensured BouncyCastle provider was properly registered by removing the Android-default BC provider, and replacing it with the standard BC provider in a Kotlin static initializer block
- added proguard rules for BC and JJWT
- ensured proper JJWT dependency declarations
